### PR TITLE
Fix bug when loading bundles classes by environment

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -29,7 +29,7 @@ class Kernel extends BaseKernel
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';
         foreach ($contents as $class => $envs) {
-            if (isset($envs['all']) || isset($envs[$this->environment])) {
+            if (isset($envs['all']) || !empty($envs[$this->environment])) {
                 yield new $class();
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Bundle classes are not loaded correctly, for example:
```php
Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['dev' => false, 'prod' => true],
```
The bundle FrameworkBundle will be loaded for both **dev** and for **prod** environments even with `'dev' => false` !!